### PR TITLE
Changes to BargraphPage

### DIFF
--- a/lib/HealthStuff/SleepRequest.dart
+++ b/lib/HealthStuff/SleepRequest.dart
@@ -1,0 +1,278 @@
+import 'package:health/health.dart';
+import 'package:sleeptrackerapp/Model/DataManager/SecureStorage.dart';
+
+class SleepRequest{
+  List<HealthDataType> datatypes = [
+    HealthDataType.SLEEP_SESSION, 
+    HealthDataType.SLEEP_ASLEEP,
+    HealthDataType.SLEEP_AWAKE,
+    HealthDataType.SLEEP_DEEP,
+    HealthDataType.SLEEP_LIGHT,
+    HealthDataType.SLEEP_REM];
+
+  var startTimes = List<DateTime>.filled(7, DateTime(0));
+  var endTimes = List<DateTime>.filled(7, DateTime(0));
+  List<HealthDataPoint> healthdata = List.empty();
+  List<double> weekHours = [0,0,0,0,0,0,0];
+  List<double> weekScores = [0,0,0,0,0,0,0];
+  List<double> sessions = [0,0,0,0,0,0,0]; List<double> rems = [0,0,0,0,0,0,0];
+  List<double> deeps = [0,0,0,0,0,0,0]; List<double> lights = [0,0,0,0,0,0,0];
+  List<double> awakes = [0,0,0,0,0,0,0];
+  double weekAvg = 0.0;
+  double sleepDebt = 0.0;
+  double sleepDebtTemp = 0.0;
+  DateTime today = DateTime.now();
+  bool loaded = false;
+
+
+  //initialize healthdata for a specific week (Must be called first)
+  Future<void> weekSleepData(DateTime sunday) async {
+    HealthFactory health = HealthFactory(useHealthConnectIfAvailable: true);
+    await health.requestAuthorization(datatypes);
+    loaded = true;
+
+    healthdata = await health.getHealthDataFromTypes(sunday, sunday.add(const Duration(days: 8)), datatypes);
+    healthdata.sort((a,b) => a.dateFrom.compareTo(b.dateFrom));
+    _sleepHours(sunday);
+    _sleepScores(sunday);
+  }
+
+  Future<bool> tryReadStorage(DateTime sunday) async {
+    String hours = await SecureStorage().readSecureData("Week - $sunday");
+    
+    if(hours.isNotEmpty && (today.isAfter(sunday.add(const Duration(days: 7))) || loaded)){
+      String avg = await SecureStorage().readSecureData("Avg - $sunday");
+      String scores = await SecureStorage().readSecureData("Scores - $sunday");
+      String starts = await SecureStorage().readSecureData("StartTimes - $sunday");
+      String ends = await SecureStorage().readSecureData("EndTimes - $sunday");
+      String sess = await SecureStorage().readSecureData("Sessions - $sunday");
+      String awks = await SecureStorage().readSecureData("Awakes - $sunday");
+      String rms = await SecureStorage().readSecureData("Rems - $sunday");
+      String deep = await SecureStorage().readSecureData("Deeps - $sunday");
+      String lghts = await SecureStorage().readSecureData("Lights - $sunday");
+
+      weekHours = parseDoubleList(hours);
+      weekAvg = double.parse(avg);
+      weekScores = parseDoubleList(scores);
+      startTimes = parseDateList(starts);
+      endTimes = parseDateList(ends);
+      sessions = parseDoubleList(sess);
+      awakes = parseDoubleList(awks);
+      rems = parseDoubleList(rms);
+      deeps = parseDoubleList(deep);
+      lights = parseDoubleList(lghts);
+      return true;
+    }
+    return false;
+  }
+
+  //set sleep_session data into appropriate days and return hours slept for the week
+  void _sleepHours(DateTime sunday) {
+    weekHours = [0,0,0,0,0,0,0];
+    startTimes = List<DateTime>.filled(7, DateTime(0));
+    endTimes = List<DateTime>.filled(7, DateTime(0));
+    var sleepSessions = healthdata.where((element) => element.type == HealthDataType.SLEEP_SESSION).toList();
+    sleepSessions = _trimEnds(sleepSessions, sunday);
+    if(sleepSessions.isEmpty) {return;}
+    healthdata.removeWhere((element) => 
+    element.dateFrom.isBefore(sleepSessions.first.dateFrom) || 
+    element.dateTo.isAfter(sleepSessions.last.dateTo));
+
+    _setDayHours(sleepSessions, sunday);
+  }
+
+  List<HealthDataPoint> _trimEnds(List<HealthDataPoint> sleepSessions, DateTime sunday) {
+      if (sleepSessions.isEmpty) return sleepSessions;
+      if(sleepSessions[0].dateTo.isBefore(sunday.add(const Duration(days: 1))) && //Checks if first sleep of the week ended before Monday
+         int.parse(sleepSessions[0].value.toString()) > 90){ //Only trims out sleep longer than 90mins to prevent trimming sunday naps
+        sleepSessions.removeAt(0);
+      }
+      if (sleepSessions.isEmpty) return sleepSessions;
+      if(sleepSessions.last.dateFrom.day != sunday.day && //last entry is not this sunday
+      sleepSessions.last.dateFrom.weekday == 7 && //last entry was on next sunday
+      sleepSessions.last.dateFrom.day != sleepSessions.last.dateTo.day){ // started on sunday, ended on monday
+        sleepSessions.removeLast();
+      }
+      return sleepSessions;
+    }
+    
+  void _setDayHours(List<HealthDataPoint> sleepSessions, DateTime sunday) {
+    for(HealthDataPoint point in sleepSessions){
+      DateTime dateFrom = point.dateFrom; DateTime dateTo = point.dateTo;
+      double value = double.parse(point.value.toString());
+
+      if(dateFrom.day == dateTo.day){ //Sleep session begun and ended on same day
+        if (value > 90) { //Sleep session was not a nap (longer than 90mins)
+          weekHours[dateTo.weekday-1] += value;
+          if(startTimes[dateTo.weekday-1] == DateTime(0)) {
+            startTimes[dateTo.weekday-1] = dateFrom;
+          }
+          endTimes[dateTo.weekday-1] = dateTo;
+        }
+        else{ //Was a nap
+          if(dateFrom.weekday == 7){ //Nap was on sunday
+            weekHours[0] += value;
+            startTimes[0] = dateFrom;
+            endTimes[0] = dateTo;
+          }
+          else{ //Nap was not on sunday
+            weekHours[dateFrom.weekday] += value;
+            startTimes[dateFrom.weekday] = dateFrom;
+            endTimes[dateFrom.weekday] = dateTo;
+          }
+        }
+      }
+      else if(dateFrom.weekday < 7){ //Sleep did not begin on a Sunday
+        weekHours[dateFrom.weekday] += value;
+        startTimes[dateFrom.weekday] = dateFrom;
+        endTimes[dateFrom.weekday] = dateTo;
+      }
+      else{
+        weekHours[0] += value;
+        startTimes[0] = dateFrom;
+        endTimes[0] = dateTo;
+      }
+    }
+  }
+  
+  void _sleepScores(DateTime sunday) {
+    weekScores = [0,0,0,0,0,0,0]; awakes = [0,0,0,0,0,0,0];
+    lights = [0,0,0,0,0,0,0]; rems = [0,0,0,0,0,0,0];
+    deeps = [0,0,0,0,0,0,0]; sessions = [0,0,0,0,0,0,0];
+    for(int i = 0; i < 7; i++){
+      if(startTimes[i] == DateTime(0)) continue;
+      double awake= 0, light = 0, rem = 0, deep = 0, asleep = 0, session = 0;
+      DateTime end = endTimes[i];
+      var toRemove = [];
+
+      for(var point in healthdata){
+        if(point.dateFrom.isAfter(end)){
+          break;
+        }
+          double value = double.parse(point.value.toString());
+        switch(point.typeString){
+        case "SLEEP_AWAKE":
+          awake += value;
+          break;
+        case "SLEEP_LIGHT":
+          light += value; 
+          break;
+        case "SLEEP_REM": 
+          rem += value;
+          break; 
+        case "SLEEP_DEEP":
+          deep += value;
+          break;
+        case "SLEEP_ASLEEP":
+          asleep += value;
+          break;
+        case "SLEEP_SESSION":
+          session += value;
+          break;
+      }
+      toRemove.add(point);
+      }
+      healthdata.removeWhere((element) => toRemove.contains(element));
+      _setDataPoints(i,session, awake, rem, deep, light);
+      weekScores[i] = _calculateScore(session, awake, rem, deep, light);
+    }
+    weekAvg = _getAvg(sunday);
+    _storeDataPoints(sunday);
+    return;
+  }
+
+  double _calculateScore(double session, double awake, double rem, double deep, double light) {
+    double duration = session-awake;
+    double remPercent = rem / session * 100;
+    double deepPercent = deep / session * 100;
+    double lightPercent = light / session * 100;
+    double awakePercent = awake / session * 100;
+    
+    double timeScore; double remScore; double deepScore;
+    double lightScore; double awakeScore;
+    
+      if(duration >= 480) {timeScore = 1;}
+      else {timeScore = duration/480;}
+      
+      remScore = remPercent/25;
+      deepScore = deepPercent/25;
+      lightScore = lightPercent/50;
+      awakeScore = awakePercent * 0.8;
+
+      if(light == 0){
+        return -1;
+      }
+      double score =  (timeScore*50)+(remScore*15)+(deepScore*15)+(lightScore*20)-(awakeScore);
+      return score.roundToDouble();
+  }
+
+  void _setDataPoints(int i, double session, double awake, double rem, double deep, double light) {
+    sessions[i] = session;
+    awakes[i] = awake;
+    rems[i] = rem;
+    deeps[i] = deep;
+    lights[i] = light;
+  }
+  
+  void _storeDataPoints(DateTime sunday) {
+      SecureStorage().writeSecureData("Week - $sunday", "$weekHours");
+      SecureStorage().writeSecureData("Scores - $sunday", "$weekScores");
+      SecureStorage().writeSecureData("Avg - $sunday", "$weekAvg");
+
+      SecureStorage().writeSecureData("Sessions - $sunday", "$sessions");
+      SecureStorage().writeSecureData("Awakes - $sunday", "$awakes");
+      SecureStorage().writeSecureData("Rems - $sunday", "$rems");
+      SecureStorage().writeSecureData("Deeps - $sunday", "$deeps");
+      SecureStorage().writeSecureData("Lights - $sunday", "$lights");
+
+      SecureStorage().writeSecureData("StartTimes - $sunday", "$startTimes");
+      SecureStorage().writeSecureData("EndTimes - $sunday", "$endTimes");
+  }
+
+    ///Converts [String] value from storage into [List] of [double] values
+  List<double> parseDoubleList(String value) {
+   value = value.replaceAll(RegExp(r'[[\]]'), '');
+   List<String> list = value.split(',');
+   List<double> list2 = list.map(double.parse).toList();
+   return list2;
+  }
+
+  List<DateTime> parseDateList(String value) {
+   value = value.replaceAll(RegExp(r'[[\]]'), '');
+   List<String> list = value.split(',');
+   for (int i = 0; i < 7; i++) {
+    list[i] = list[i].trim();
+   }
+   List<DateTime> list2 = list.map<DateTime>((DateTime.parse)).toList();
+   return list2;
+  }
+  
+  double _getAvg(DateTime sunday) {
+    double totalSlept=0.0;
+    double daysRecorded=0.0;
+
+    for(int i = 0; i < weekHours.length; i++){
+      if(weekHours[i] == 0) continue;
+      totalSlept += weekHours[i];
+      daysRecorded++;
+    }
+    if(totalSlept == 0) return 0.0;
+
+    double avg = totalSlept/daysRecorded;
+    sleepDebtTemp += ((daysRecorded * 8 * 60) - (totalSlept));
+    if(today.isAfter(sunday.add(const Duration(days: 7)))){
+      sleepDebt = sleepDebtTemp;
+      SecureStorage().writeSecureData("SleepDebt", "$sleepDebt");
+    }
+    return avg;
+  }
+
+    void setSleepDebt() async {
+    String value = await SecureStorage().readSecureData("SleepDebt");
+    if(value != '') {
+      sleepDebt = double.parse(value);
+      sleepDebtTemp = sleepDebt;
+    }
+  }
+
+}

--- a/lib/Pages/BarGraphPage.dart
+++ b/lib/Pages/BarGraphPage.dart
@@ -1,14 +1,12 @@
 import 'dart:collection';
-
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
-import 'package:health/health.dart';
 import 'package:intl/intl.dart';
 import 'package:sleeptrackerapp/Pages/NavigationPanel.dart';
-import 'package:sleeptrackerapp/Model/DataManager/SecureStorage.dart';
 import 'package:sleeptrackerapp/Widgets/bar_graph/bar_graph_week.dart';
 import 'package:sleeptrackerapp/Widgets/bar_graph/bar_graph_month.dart';
+import 'package:sleeptrackerapp/Widgets/SleepDebt.dart';
+import 'package:sleeptrackerapp/HealthStuff/SleepRequest.dart';
+import 'package:sleeptrackerapp/Widgets/ScoreViewer.dart';
 
 class BarGraphPage extends StatefulWidget{
   const BarGraphPage({super.key, required this.title});
@@ -19,28 +17,34 @@ class BarGraphPage extends StatefulWidget{
 }
 
 class BarGraphPageState extends State<BarGraphPage>{
-  late DateTime today = setSunday(DateTime.now().toUtc());
-  late DateTime selectedDay = setSunday(DateTime.now().toUtc());
+  late DateTime today = setSunday(DateTime.now());
+  late DateTime selectedDay = setSunday(DateTime.now());
+
   DateFormat df = DateFormat.Md();
   late String weekLabel = "${df.format(selectedDay)} - ${df.format(selectedDay.add(const Duration(days: 6)))}";
 
-  List<HealthDataType> datatypes = [HealthDataType.SLEEP_SESSION];
+  SleepRequest request = SleepRequest();
+
   List<double> weeklyHours = [0,0,0,0,0,0,0];
   List<double> monthlySummary = [0,0,0,0,0];
-  HashMap mapWeeks = HashMap<DateTime,List<double>>();
-  HashMap mapAvgs = HashMap<DateTime,double>();
+  List<double> scoresWeek = [0,0,0,0,0,0,0];
+  List<DateTime> startTimes = List.filled(7, DateTime(0));
+  List<DateTime> endTimes = List.filled(7, DateTime(0));
+
   double avgSlept = 0.0;
   double sleepDebt = 0.0;
   double sleepDebtTemp = 0.0;
 
   bool weekEnabled = true;
   bool monthEnabled = false; 
+  bool ready = false;
+
+  
 
   @override
   void initState(){
-    setSleepDebt();
+    request.setSleepDebt();
     setChartWeek();
-    deleteExtraWeeks();
     super.initState();
   }
 
@@ -49,128 +53,14 @@ class BarGraphPageState extends State<BarGraphPage>{
     super.dispose();
   }
 
-
-  ///Requests Sleep Session data for specified week beginning on [sunday] from Health Connect 
-  ///and saves daily values into global [weeklyHours]
-  ///
-  ///Returns [double] value for the average hours slept on specified week
-  Future<double> hoursSleptWeek(DateTime sunday) async {
-    HealthFactory health = HealthFactory(useHealthConnectIfAvailable: true);
-    await health.requestAuthorization(datatypes);
-
-    List<HealthDataPoint> healthdata = await health.getHealthDataFromTypes(sunday, sunday.add(const Duration(days: 8)), datatypes);
-    //Trim out last weeks Saturday night sleep if it started after midnight
-    healthdata = trimEnds(healthdata, sunday);
-    fillBarChartWeek(healthdata);
-    
-    mapWeeks.putIfAbsent(sunday, () => weeklyHours);
-    writeToStorage(sunday);
-    return avgHoursWeek(sunday);
-    }
-
-  ///Writes [weeklyHours] into storage using [sunday] of a specific week as the key
-  void writeToStorage(DateTime sunday) {
-    if(today.isAfter(sunday) && sunday.isAfter(today.subtract(const Duration(days: 36)))) { //save week into storage if not current week AND is within the last 5 weeks
-      SecureStorage().writeSecureData("Week - $sunday", "$weeklyHours");
-    }
-  }
-
-  ///Returns the average hours slept for a given week and writes avg into memory.
-  ///Only writes week into memory if it is within last 5 weeks
-  double avgHoursWeek(DateTime selectedDay) {
-    double totalSlept=0.0;
-    double daysRecorded=0.0;
-    
-    for(int i = 0; i < weeklyHours.length; i++){
-      if(weeklyHours[i] == 0) continue;
-      totalSlept += weeklyHours[i];
-      daysRecorded++;
-    }
-    if(totalSlept == 0.0) {
-      mapAvgs.putIfAbsent(selectedDay, () => 0.0);
-      if(today.isAfter(selectedDay) && selectedDay.isAfter(today.subtract(const Duration(days: 36)))) {
-        SecureStorage().writeSecureData("Avg - $selectedDay", "0.0");
-      }
-      return 0.0;
-    }
-    double avg = totalSlept/daysRecorded/60;
-    mapAvgs.putIfAbsent(selectedDay, () => avg);
-    sleepDebtTemp += (daysRecorded * 8) - (totalSlept/60);
-    if (today.isAfter(selectedDay) && selectedDay.isAfter(today.subtract(const Duration(days: 36)))) {
-      sleepDebt += (daysRecorded * 8) - (totalSlept/60);
-      SecureStorage().writeSecureData("Avg - $selectedDay", "$avg");
-      SecureStorage().writeSecureData("SleepDebt", "$sleepDebt");
-    }
-    return mapAvgs[selectedDay];
-  }
-
   ///Returns the [DateTime] object of midnight on Sunday of the calendar week of [selectedDay]
   DateTime setSunday(DateTime selectedDay) {
     int day = selectedDay.weekday; //Day of the week (Mon = 1, Tue = 2, ...)
     
-    DateTime sunday = day < 7 ? 
-    selectedDay.subtract(Duration(
-      days: day, 
-      hours: selectedDay.hour, 
-      minutes: selectedDay.minute, 
-      seconds: selectedDay.second,
-      milliseconds: selectedDay.millisecond, 
-      microseconds: selectedDay.microsecond)) : //Midnight of first calendar day(Sunday) of current week
-    selectedDay.subtract(Duration(
-      days: 7, 
-      hours: selectedDay.hour, 
-      minutes: selectedDay.minute, 
-      seconds: selectedDay.second,
-      milliseconds: selectedDay.millisecond, 
-      microseconds: selectedDay.microsecond)); //current day is already Sunday, set to previous weeks Sunday
-    
-    if(selectedDay == sunday){
-      sunday = sunday.subtract(const Duration(days: 7));
-    }
+    DateTime sunday = selectedDay.subtract(Duration(days: day));
+    sunday = DateTime(sunday.year,sunday.month,sunday.day);
     return sunday;
-  }
-
-  ///Retruns modified [List] of [HealthDataPoints] with the first and last entries trimmed out if they fall outside of desired week
-  List<HealthDataPoint> trimEnds(List<HealthDataPoint> healthdata, DateTime sunday) {
-      if (healthdata.isEmpty) return healthdata;
-      if(healthdata[0].dateTo.isBefore(sunday.add(const Duration(days: 1))) && //Checks if first sleep of the week ended before Monday
-         int.parse(healthdata[0].value.toString()) > 90){ //Only trims out sleep longer than 90mins to prevent trimming sunday naps
-        healthdata.removeAt(0);
-      }
-      if (healthdata.isEmpty) return healthdata;
-      if(healthdata.last.dateFrom.day != sunday.day && //last entry is not this sunday
-      healthdata.last.dateFrom.weekday == 7 && //last entry was on next sunday
-      healthdata.last.dateFrom.day != healthdata.last.dateTo.day){ // started on sunday, ended on monday
-        healthdata.removeLast();
-      }
-      return healthdata;
-    }
-
-  ///Uses Health Connect data to populate [weeklyHours]
-  void fillBarChartWeek(List<HealthDataPoint> healthdata) {
-    weeklyHours = [0,0,0,0,0,0,0];
-    if (healthdata.isEmpty) return;
-      for(int i = 0; i < healthdata.length;i++){
-        if(healthdata[i].dateFrom.day == healthdata[i].dateTo.day &&
-          int.parse(healthdata[i].value.toString()) > 90){ //If sleep session occurred after midnight and was not a nap
-            weeklyHours[healthdata[i].dateTo.weekday-1] += double.parse(healthdata[i].value.toString()); //Set that as previous night's sleep hours
-        }
-        else if(healthdata[i].dateFrom.day == healthdata[i].dateTo.day && int.parse(healthdata[i].value.toString()) <= 90){ //Nap defined at most 90 mins counts towards day it occurred
-          if(healthdata[i].dateFrom.weekday == 7){ //If sunday (cant use weekday value)
-            weeklyHours[0] += double.parse(healthdata[i].value.toString()); //nap hours added to sunday
-          }
-          else {
-            weeklyHours[healthdata[i].dateFrom.weekday] += double.parse(healthdata[i].value.toString()); //nap hours added to day of the week
-          }
-        }
-        else if(healthdata[i].dateFrom.weekday < 7){ //start was different day than end and did not start on Sunday
-          weeklyHours[healthdata[i].dateFrom.weekday] += double.parse(healthdata[i].value.toString());
-        }
-        else{
-          weeklyHours[0] += double.parse(healthdata[i].value.toString());
-        }
-      }
-    }   
+  }  
 
   @override
   Widget build(BuildContext context) {
@@ -206,36 +96,17 @@ class BarGraphPageState extends State<BarGraphPage>{
               children: [
               weekEnabled ? IconButton(onPressed: leftArrow, icon: const Icon(Icons.chevron_left)) : const SizedBox(height: 48,),
               Text(weekEnabled ? weekLabel : "Weekly Sleep Average", style: const TextStyle(fontSize: 24),),
-              weekEnabled ? IconButton(onPressed: selectedDay != today ? rightArrow : null, icon: const Icon(Icons.chevron_right)) : const SizedBox()
+              weekEnabled ? IconButton(onPressed: selectedDay != today ? rightArrow : null, icon: const Icon(Icons.chevron_right)) 
+              : const SizedBox()
           ],),
             Text("Average: ${tooltipText(avgSlept)}"),
             displayBars(),
             const Divider(),
             SizedBox( width: 300,height: 100, 
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.start,
-                children: [
-                const Text("Sleep Debt", style: TextStyle(fontSize: 24)),
-                Row(
-                  children: [
-                    const Column(
-                      crossAxisAlignment: CrossAxisAlignment.end,
-                      children: [
-                      Text("Total:",style: TextStyle(fontSize: 20),),
-                      Text("This Week:",style: TextStyle(fontSize: 20),),
-                      ],),
-                      const SizedBox(width: 100,),
-                      Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                      Text(tooltipText(sleepDebtTemp),style: const TextStyle(fontSize: 20),),
-                      Text(tooltipText(setWeekDebt()),style: const TextStyle(fontSize: 20),),
-                      ],),
-                  ],
-                ),
-            ],),
+              child: SleepDebt(weeklyHours: weeklyHours, sleepDebtTemp: sleepDebtTemp),
             ),
-            const Divider()
+            weekEnabled ? ScoreViewWidget(weekScores: scoresWeek, sunday: selectedDay, startTimes: startTimes, endTimes: endTimes) 
+            : const SizedBox()
         ],),
         ),
       ),
@@ -248,7 +119,10 @@ class BarGraphPageState extends State<BarGraphPage>{
       height: 260,
       margin: const EdgeInsets.only(right: 20),
       padding: const EdgeInsets.only(top: 35,bottom: 10), 
-      child: weekEnabled ? BarGraphWeek(weeklySummary: weeklyHours) : BarGraphMonth(monthlySummary: monthlySummary)
+      child: Stack(children: [
+        weekEnabled ? BarGraphWeek(weeklySummary: weeklyHours) : 
+        BarGraphMonth(monthlySummary: monthlySummary),
+        Align(alignment: Alignment.center,child: ready ? null: const CircularProgressIndicator())],)
     );
   }
 
@@ -256,51 +130,36 @@ class BarGraphPageState extends State<BarGraphPage>{
   void buttonChange() {
     weekEnabled = !weekEnabled;
     monthEnabled = !monthEnabled;
-    if(weekEnabled){
-      setChartWeek();
-    }
-    else{
-      setChartMonth();
-    }
+    if(weekEnabled){setChartWeek();}
+    else{setChartMonth();}
   }
 
   ///Retrieves Health Connect data for specified week if it is not already in storage
   void setChartWeek() async {
-      /*Reset weekly hours to 0 because loop adds onto existing value
-        instead of setting value to account for naps*/
-      weeklyHours = [0,0,0,0,0,0,0];
-      avgSlept = 0;
-      String value = await SecureStorage().readSecureData("Week - $selectedDay");
-      String avg = await SecureStorage().readSecureData("Avg - $selectedDay");
-      if(value != ''){
-        weeklyHours = parseStorageValue(value);
-        avgSlept = double.parse(avg);
-      }else if(mapWeeks.containsKey(selectedDay)){
-        weeklyHours = mapWeeks[selectedDay];
-        avgSlept = mapAvgs[selectedDay];
-      }
-      else {
-        avgSlept = await hoursSleptWeek(selectedDay);
-      }
-      weekLabel = "${df.format(selectedDay)} - ${df.format(selectedDay.add(const Duration(days: 6)))}";
-      setState(() {});
+    weekLabel = "${df.format(selectedDay)} - ${df.format(selectedDay.add(const Duration(days: 6)))}";
+    if(!await request.tryReadStorage(selectedDay)){
+      setState(() {ready = false; weeklyHours = [0,0,0,0,0,0,0]; scoresWeek = [0,0,0,0,0,0,0]; avgSlept = 0;});
+      await request.weekSleepData(selectedDay);
+    }
+    weeklyHours = request.weekHours;
+    scoresWeek = request.weekScores;
+    avgSlept = request.weekAvg;
+    startTimes = request.startTimes;
+    endTimes = request.endTimes;
+    sleepDebtTemp = request.sleepDebtTemp;
+    setState(() {ready = true;});
   }
 
   ///Retrieves Health Connect data for last 5 weeks if they are not already in storage
   void setChartMonth() async {
     setState(() {});
-    DateTime curr = setSunday(DateTime.now().toUtc());
+    DateTime curr = today;
     for(int i = 4; i >= 0; i-- ){
-      String value = await SecureStorage().readSecureData("Avg - $curr");
-      if(value != ''){
-        monthlySummary[i] = double.parse(value);
+      if (!await request.tryReadStorage(curr)){
+        setState(() {ready = false;});
+        await request.weekSleepData(curr);
       }
-      else if(mapAvgs.containsKey(curr)){
-        monthlySummary[i] = mapAvgs[curr];
-      }
-      else{
-        monthlySummary[i] = await hoursSleptWeek(curr);
-      }
+      monthlySummary[i] = request.weekAvg;
       curr = curr.subtract(const Duration(days: 7));
   }
   setState(() {
@@ -311,92 +170,26 @@ class BarGraphPageState extends State<BarGraphPage>{
       total += monthlySummary[i];
       daysRecorded++;
     }
-    if(daysRecorded > 0) {
-      avgSlept = total/daysRecorded;
-    }
+    if(daysRecorded > 0) {avgSlept = total/daysRecorded;}
+    ready = true;
   });
   }
 
-  ///Converts [double] value of hours into String #0H #0m format
-  String tooltipText(double hours){
-    String hourText = '0';
-    String minsText = '0';
-    if(hours == 0.0) {
-      return "0H 0m";
-    } else if (hours >= 1) {
-      hourText = hours.floor().toString();
-      double mins = hours % hours.floor();
-      minsText = (60 * mins).floor().toString();
-    } else if(hours > 0 && hours < 1){
-      hours+=1;
-      double mins = hours % hours.floor();
-      minsText = (60 * mins).floor().toString();
-    } else if(hours < 0 && hours > -1){
-      hours-=1;
-      double mins = hours - hours.ceil();
-      minsText = (60 * mins).ceil().toString();
-    } else {
-      hourText = hours.ceil().toString();
-      double mins = hours - hours.ceil();
-      minsText = (60*mins).ceil().toString();
-    }
-    return "${hourText}H ${minsText}m";
+  String tooltipText(double minutes){
+    int hours = (minutes / 60).floor();
+    int mins = (minutes % 60).floor();
+    return "${hours}H ${mins}m";
   }
 
   ///selected week moves backwards 1 week
   void leftArrow() {
     selectedDay = selectedDay.subtract(const Duration(days: 7));
-    setChartWeek();
+    setState(() {setChartWeek();});
   }
 
   ///selected week moves forward 1 week
   void rightArrow() {
     selectedDay = selectedDay.add(const Duration(days: 7));
-    setChartWeek();
+    setState(() {setChartWeek();});
   }
-  
-  ///Converts [String] value from storage into [List] of [double] values
-  List<double> parseStorageValue(String value) {
-   value = value.replaceAll(RegExp(r'[[\]]'), '');
-   List<String> list = value.split(',');
-   List<double> list2 = list.map(double.parse).toList();
-   return list2;
-  }
-  
-  ///Retrieves sleepDebt total from storage
-  void setSleepDebt() async {
-    String value = await SecureStorage().readSecureData("SleepDebt");
-    if(value != '') {
-      sleepDebt = double.parse(value);
-      sleepDebtTemp = sleepDebt;
-    }
-  }
-
-  ///Calculates and returns sleepDebt for current selected Week
-  double setWeekDebt(){
-    int daysRecorded = 0;
-    double total = 0;
-    for(int i = 0; i < weeklyHours.length; i++){
-      if(weeklyHours[i] != 0){
-        total+= weeklyHours[i];
-        daysRecorded++;
-      }
-    }
-    if(total == 0) return 0;
-    return (daysRecorded*8) - (total/60);
-  }
-  
-  void deleteExtraWeeks() async{
-    DateTime earliest = today.subtract(const Duration(days: 35));
-    Map storageMap = await SecureStorage().readAll();
-
-    for(dynamic key in storageMap.keys){
-      if(key.contains('Week') || key.contains("Avg")){
-        String temp = key.substring(key.indexOf('2'));
-        if(DateTime.parse(temp).isBefore(earliest)){
-          SecureStorage().deleteSecureData(key);
-        }
-      }
-    }
-  } 
 }

--- a/lib/Widgets/ScoreViewer.dart
+++ b/lib/Widgets/ScoreViewer.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class ScoreViewWidget extends StatelessWidget {
+  ScoreViewWidget({
+    required this.weekScores,
+    required this.sunday,
+    required this.startTimes,
+    required this.endTimes,
+    super.key,
+  });
+
+  List<double> weekScores;
+  DateTime sunday;
+  List<DateTime> startTimes;
+  List<DateTime> endTimes;
+
+  late final List<Widget> scoreViews = [
+    ScoreCard(score: weekScores[0], startTime: startTimes[0], endTime: endTimes[0], title: "Sunday", date: sunday), 
+    ScoreCard(score: weekScores[1], startTime: startTimes[1], endTime: endTimes[1], title: "Monday", date: sunday.add(const Duration(days: 1))),
+    ScoreCard(score: weekScores[2], startTime: startTimes[2], endTime: endTimes[2], title: "Tuesday", date: sunday.add(const Duration(days: 2))), 
+    ScoreCard(score: weekScores[3], startTime: startTimes[3], endTime: endTimes[3], title: "Wednesday", date: sunday.add(const Duration(days: 3))),
+    ScoreCard(score: weekScores[4], startTime: startTimes[4], endTime: endTimes[4], title: "Thursday", date: sunday.add(const Duration(days: 4))), 
+    ScoreCard(score: weekScores[5], startTime: startTimes[5], endTime: endTimes[5], title: "Friday", date: sunday.add(const Duration(days: 5))),
+    ScoreCard(score: weekScores[6], startTime: startTimes[6], endTime: endTimes[6], title: "Saturday", date: sunday.add(const Duration(days: 6))),
+    ];
+
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: scoreViews
+    );
+  }
+}
+
+class ScoreCard extends StatelessWidget {
+
+    ScoreCard({
+    required this.title,
+    required this.score,
+    required this.date,
+    required this.startTime,
+    required this.endTime,
+    super.key, 
+  });
+
+  final Color lav = const Color.fromARGB(255, 160, 109, 186);
+
+  final DateTime startTime;
+  final DateTime endTime;
+  final double score;
+  final String title;
+  final DateTime date;
+  final DateFormat Md = DateFormat.Md();
+  final DateFormat jm = DateFormat.jm();
+
+  @override
+  Widget build(BuildContext context) {
+    String scoreText;
+      if(score == -1){scoreText = 'NA';}
+      else{scoreText = score.round().toString();}
+      return ((score != 0) && (!score.isNaN)) ? Column(
+      children: [
+        Container(color: lav, width: double.infinity,
+        child: Padding(padding: const EdgeInsets.only(left: 5),
+          child: Text("$title - ${Md.format(date)}", style: const TextStyle(fontWeight: FontWeight.bold, color: Colors.white,  fontSize: 14),),
+        ),),
+        Center(
+          child: Ink( 
+            height: 80, 
+            child: InkWell(
+              onTap: () { /* ... */ },
+              child: Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 15),
+                child: Row(
+                  children: [
+                  Container(
+                    width: 50,
+                    height: 50, 
+                    decoration: const BoxDecoration(color: Colors.deepPurple, shape: BoxShape.circle), 
+                    child: Center(child: Text(scoreText, style: const TextStyle(fontSize: 20, color: Colors.white, fontWeight: FontWeight.bold),)),
+                    ),
+                    Padding(
+                      padding: const EdgeInsets.only(left: 60),
+                      child: Text("${jm.format(startTime)} - ${jm.format(endTime)}", style: TextStyle(fontSize: 20, ),),
+                    ),
+                    ]),
+              ),
+          )),
+        ),
+      ],
+    ) : const SizedBox();
+    
+  }
+}

--- a/lib/Widgets/SleepDebt.dart
+++ b/lib/Widgets/SleepDebt.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/cupertino.dart';
+
+class SleepDebt extends StatefulWidget{
+  const SleepDebt({super.key,
+  required this.weeklyHours,
+  required this.sleepDebtTemp
+  });
+  final List<double> weeklyHours;
+  final double sleepDebtTemp;
+
+  @override
+  State<SleepDebt> createState() => SleepDebtState();
+}
+
+  String tooltipText(double minutes){
+    int hours, mins;
+    if(minutes > 0){
+      hours = (minutes / 60).floor();
+      mins = (minutes % 60).floor();
+      }
+    else{
+      hours = (minutes / 60).ceil();
+      mins = (-1*minutes % 60).floor();
+      if(hours == 0){mins*=-1;}
+    }
+    return "${hours}H ${mins}m";
+  }
+
+class SleepDebtState extends State<SleepDebt>{
+    double setWeekDebt(){
+    int daysRecorded = 0;
+    double total = 0;
+    for(int i = 0; i < widget.weeklyHours.length; i++){
+      if(widget.weeklyHours[i] != 0){
+        total+= widget.weeklyHours[i];
+        daysRecorded++;
+      }
+    }
+    if(total == 0) return 0;
+    return ((daysRecorded*8*60) - (total));
+  }
+
+  @override
+  Widget build(BuildContext context) {
+      return Column(
+              mainAxisAlignment: MainAxisAlignment.start,
+              children: [
+              const Text("Sleep Debt", style: TextStyle(fontSize: 24)),
+              Row(
+                children: [
+                  const Column(
+                    crossAxisAlignment: CrossAxisAlignment.end,
+                    children: [
+                    Text("Total:",style: TextStyle(fontSize: 20),),
+                    Text("This Week:",style: TextStyle(fontSize: 20),),
+                    ],),
+                    const SizedBox(width: 100,),
+                    Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                    Text(tooltipText(widget.sleepDebtTemp),style: const TextStyle(fontSize: 20)),
+                    Text(tooltipText(setWeekDebt()),style: const TextStyle(fontSize: 20)),
+                    ],),
+                ],
+              ),
+          ],);
+  } 
+}

--- a/lib/Widgets/bar_graph/bar_graph_month.dart
+++ b/lib/Widgets/bar_graph/bar_graph_month.dart
@@ -10,11 +10,11 @@ class BarGraphMonth extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     BarDataMonth myBarData = BarDataMonth(
-        week1: monthlySummary[0],
-        week2: monthlySummary[1],
-        week3: monthlySummary[2],
-        week4: monthlySummary[3],
-        week5: monthlySummary[4]);
+        week1: monthlySummary[0] / 60,
+        week2: monthlySummary[1] / 60,
+        week3: monthlySummary[2] / 60,
+        week4: monthlySummary[3] / 60,
+        week5: monthlySummary[4] / 60);
 
     myBarData.initializeBarData();
     return BarChart(BarChartData(
@@ -65,7 +65,7 @@ class BarGraphMonth extends StatelessWidget {
     ));
   }
 
-    String tooltipText(double hours){
+  String tooltipText(double hours){
     if(hours == 0) return "0H 0m";
     String hourText = hours.floor().toString();
     double mins = hours % hours.floor();


### PR DESCRIPTION
- New class SleepRequest is used to request healthconnect data for a specific week and all bargraphPage data lives here.
- SleepRequest contains a new method for calculating sleepScore based on hours slept, rem & deep sleep, and restlessness.
- Widget SleepDebt was extracted from bargraphPage to reduce clutter
- Widget ScoreViewer displays cards with sleep scores and sleep times

-----------------------------------------------------------------------------------------------------------------------------------------

- Plan is to modify statistics page to pull data from SleepRequest so all data is consistent and user can click on score card in bargraphPage and open the full statistics page for that day